### PR TITLE
wait, that parameter is named something else

### DIFF
--- a/fabdocker/docker.py
+++ b/fabdocker/docker.py
@@ -94,7 +94,7 @@ class Docker(object):
         cmd = "build -t {image}{tag} {build_arg} {directory}".format(
             image=image,
             tag=":{}".format(tag) if tag else "",
-            build_arg=" ".join(["--build-args {}={}".format(k, v) for k, v in build_arg.iteritems()]),
+            build_arg=" ".join(["--build-arg {}={}".format(k, v) for k, v in build_arg.iteritems()]),
             directory=directory
         )
         return self(cmd, local)


### PR DESCRIPTION
This library claims to support the "--build-arg" parameter but doesn't actually, due to a typo. I presume this fixes it, but I haven't tested, because I don't have fabric running locally.